### PR TITLE
Fixed constructors to be php7 compliant

### DIFF
--- a/eSELECTplus_PHP_NA_API_v105_Full/mpgClasses.php
+++ b/eSELECTplus_PHP_NA_API_v105_Full/mpgClasses.php
@@ -42,7 +42,7 @@ class httpsPost
 	var $response;
 	var $debug = FALSE; //default is false for production release
 
-	function httpsPost($url, $dataToSend)
+	function __construct($url, $dataToSend)
 	{
 		$this->url=$url;
 		$this->dataToSend=$dataToSend;
@@ -100,7 +100,7 @@ class mpgHttpsPost
  	var $txnType;
  	var $isMPI;
 
- 	function mpgHttpsPost($storeid,$apitoken,$mpgRequestOBJ)
+ 	function __construct($storeid,$apitoken,$mpgRequestOBJ)
  	{
 
   		$this->store_id=$storeid;
@@ -202,7 +202,7 @@ class mpgHttpsPostStatus
  	var $mpgResponse;
  	var $xmlString;
 
- 	function mpgHttpsPostStatus($storeid,$apitoken,$status,$mpgRequestOBJ)
+ 	function __construct($storeid,$apitoken,$status,$mpgRequestOBJ)
  	{
 
   		$this->store_id=$storeid;
@@ -325,7 +325,7 @@ class mpgResponse
  	var $results = array();
  	var $rules = array();
 
- 	function mpgResponse($xmlString)
+ 	function __construct($xmlString)
  	{
 
   		$this->p = xml_parser_create();
@@ -1450,8 +1450,6 @@ class mpgResponse
  		return $this->getMpgResponseValue($this->cardHash,$ecr);
 	}
 
-
-
 	function characterHandler($parser,$data)
 	{
 		if($this->isBatchTotals)
@@ -1931,7 +1929,7 @@ class mpgRequest
 	var $testMode = "";
 	var $isMPI = "";
 	
-	function mpgRequest($txn)
+	function __construct($txn)
 	{
 
  		if(is_array($txn))
@@ -2163,7 +2161,7 @@ class mpgCustInfo
  	var $email;
  	var $instructions;
 
- 	function mpgCustInfo($custinfo=0,$billing=0,$shipping=0,$items=0)
+ 	function __construct($custinfo=0,$billing=0,$shipping=0,$items=0)
  	{
  		if($custinfo)
    		{
@@ -2277,7 +2275,7 @@ class mpgRecur{
 	var $params;
 	var $recurTemplate = array('recur_unit','start_now','start_date','num_recurs','period','recur_amount');
 
-	function mpgRecur($params)
+	function __construct($params)
 	{
 		$this->params = $params;
 		if( (! $this->params['period']) )
@@ -2308,7 +2306,7 @@ class mpgAvsInfo
     var $params;
     var $avsTemplate = array('avs_street_number','avs_street_name','avs_zipcode','avs_email','avs_hostname','avs_browser','avs_shiptocountry','avs_shipmethod','avs_merchprodsku','avs_custip','avs_custphone');
 
-    function mpgAvsInfo($params)
+    function __construct($params)
     {
         $this->params = $params;
     }
@@ -2339,7 +2337,7 @@ class mpgCvdInfo
     var $params;
     var $cvdTemplate = array('cvd_indicator','cvd_value');
 
-    function mpgCvdInfo($params)
+    function __construct($params)
     {
         $this->params = $params;
     }
@@ -2369,7 +2367,7 @@ class mpgAchInfo
 			'cust_state','cust_zip','routing_num','account_num',
 			'check_num','account_type','micr');
 
-	function mpgAchInfo($params)
+	function __construct($params)
 	{
 		$this->params = $params;
 	}
@@ -2396,7 +2394,7 @@ class mpgConvFeeInfo
 	var $params;
 	var $convFeeTemplate = array('convenience_fee');
 
-	function mpgConvFeeInfo($params)
+	function __construct($params)
 	{
 		$this->params = $params;
 	}
@@ -2431,7 +2429,7 @@ class mpgTransaction
 	var $attributeAccountInfo = null;
 	var $level23Data = null;
 
-	function mpgTransaction($txn)
+	function __construct($txn)
 	{
 		$this->txn=$txn;
 	}
@@ -2554,7 +2552,7 @@ class MpiHttpsPost
 	var $mpiRequest;
 	var $mpiResponse;
 
-	function MpiHttpsPost($storeid,$apitoken,$mpiRequestOBJ)
+	function __construct($storeid,$apitoken,$mpiRequestOBJ)
 	{
 
 		$this->store_id=$storeid;
@@ -2587,8 +2585,6 @@ class MpiHttpsPost
 		$this->mpiResponse=new MpiResponse($response);
 			
 	}
-
-
 
 	function getMpiResponse()
 	{
@@ -2630,7 +2626,7 @@ class MpiResponse{
 
 	var $ACSUrl;
 
-	function MpiResponse($xmlString)
+	function __construct($xmlString)
 	{
 
 		$this->p = xml_parser_create();
@@ -2822,7 +2818,7 @@ class MpiRequest
 	var $procCountryCode = "";
 	var $testMode = "";
 
-	function MpiRequest($txn)
+	function __construct($txn)
 	{
 
 		if(is_array($txn))
@@ -2920,7 +2916,7 @@ class MpiTransaction
 {
 	var $txn;
 
-	function MpiTransaction($txn)
+	function __construct($txn)
 	{
 		$this->txn=$txn;
 	}
@@ -2941,7 +2937,7 @@ class riskHttpsPost{
 	var $riskRequest;
 	var $riskResponse;
 
-	function riskHttpsPost($storeid,$apitoken,$riskRequestOBJ)
+	function __construct($storeid,$apitoken,$riskRequestOBJ)
 	{
 
 		$this->store_id=$storeid;
@@ -2972,8 +2968,6 @@ class riskHttpsPost{
 		$this->riskResponse=new riskResponse($response);
 
 	}
-
-
 
 	function getRiskResponse()
 	{
@@ -3020,7 +3014,7 @@ class riskResponse{
 	var $results = array();
 	var $rules = array();
 
-	function riskResponse($xmlString)
+	function __construct($xmlString)
 	{
 
 		$this->p = xml_parser_create();
@@ -3269,7 +3263,7 @@ class mpgSessionAccountInfo
 											'shipping_address_state','shipping_address_country','shipping_address_zip','local_attrib_1','local_attrib_2','local_attrib_3','local_attrib_4',
 											'local_attrib_5','transaction_amount','transaction_currency');
 
-	function mpgSessionAccountInfo($params)
+	function __construct($params)
 	{
 		$this->params = $params;
 	}
@@ -3300,7 +3294,7 @@ class mpgAttributeAccountInfo
 											'account_address_state','account_address_country','account_address_zip','shipping_address_street1','shipping_address_street2','shipping_address_city',
 											'shipping_address_state','shipping_address_country','shipping_address_zip');
 
-	function mpgAttributeAccountInfo($params)
+	function __construct($params)
 	{
 		$this->params = $params;
 	}
@@ -3330,7 +3324,7 @@ class riskTransaction{
 	var $attributeAccountInfo = null;
 	var $sessionAccountInfo = null;
 
-	function riskTransaction($txn)
+	function __construct($txn)
 	{
 		$this->txn=$txn;
 	}


### PR DESCRIPTION
Changes all the old-style class name constructors to the newer __construct() style, as they have been deprecated since PHP5 and are now throwing notices in PHP7.