### PR TITLE
Update mpgRequest toXml() to accept txn type at any position in the txn array

### DIFF
--- a/mpgClasses.php
+++ b/mpgClasses.php
@@ -2046,7 +2046,8 @@ class mpgRequest
 			$txnObj=$tmpTxnArray[$x];
 			$txn=$txnObj->getTransaction();
 
-			$txnType=array_shift($txn);
+			$txnType = $txn['type'];
+			unset($txn['type']);
 			if (($this->procCountryCode === "_US") && (strpos($txnType, "us_") !== 0))
 			{
 				if((strcmp($txnType, "txn") === 0) || (strcmp($txnType, "acs") === 0) || (strcmp($txnType, "group") === 0))


### PR DESCRIPTION
The Moneris developer docs are not explicit about the type needing to be the first value in the transaction array. Since it is already an associative array I propose that the 'type' key be used when determining the transaction type instead of relying on it being the first value in the array provided by the merchant.